### PR TITLE
Unsigned 'available' API

### DIFF
--- a/cores/arduino/xinput/USB_XInput_API.cpp
+++ b/cores/arduino/xinput/USB_XInput_API.cpp
@@ -34,7 +34,7 @@ boolean XInputUSB::connected() {
 	return USBDevice.configured();
 }
 
-int XInputUSB::available() {
+uint8_t XInputUSB::available() {
 	return USB_Available(XINPUT_RX_ENDPOINT);
 }
 

--- a/cores/arduino/xinput/USB_XInput_API.h
+++ b/cores/arduino/xinput/USB_XInput_API.h
@@ -37,9 +37,9 @@ class XInputUSB {
 public:
 	// API
 	static bool connected(void);
-	static int  available(void);
-	static int  send(const void *buffer, uint8_t nbytes);
-	static int  recv(void *buffer, uint8_t nbytes);
+	static uint8_t available(void);
+	static int send(const void *buffer, uint8_t nbytes);
+	static int recv(void *buffer, uint8_t nbytes);
 	static void setRecvCallback(void(*callback)(void));
 
 	// Non-API Data


### PR DESCRIPTION
Changes the 'available' function to return an unsigned integer rather than an 'int', because the function never throws an error (-1) and the number of bytes available will never be negative. Using `uint8_t` to match the return value for the Arduino USB stack.

Since I was already tweaking the API files, I also re-ordered the header so that the 'send' function was below the 'recv' function. This groups the two 'recv' functions together, and matches the typical order you talk about the functions (send/recv).