### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,52 +45,40 @@ install:
 
 script:
   # Arduino Yún w/ XInput
-  - BOARD=xinput:avr:yun
-  - buildSketch
+  - BOARD=xinput:avr:yun; buildSketch;
 
   # Arduino Leonardo w/ XInput
-  - BOARD=xinput:avr:leonardo
-  - buildSketch
+  - BOARD=xinput:avr:leonardo; buildSketch;
 
   # Arduino Arduino Leonardo ETH w/ XInput
-  - BOARD=xinput:avr:leonardoeth
-  - buildSketch
+  - BOARD=xinput:avr:leonardoeth; buildSketch;
 
   # Arduino/Genuino Micro w/ XInput
-  - BOARD=xinput:avr:micro
-  - buildSketch
+  - BOARD=xinput:avr:micro; buildSketch;
 
   # Arduino Esplora w/ XInput
-  - BOARD=xinput:avr:esplora
-  - buildSketch
+  - BOARD=xinput:avr:esplora; buildSketch;
 
   # LilyPad Arduino USB w/ XInput
-  - BOARD=xinput:avr:LilyPadUSB
-  - buildSketch
+  - BOARD=xinput:avr:LilyPadUSB; buildSketch;
 
   # Arduino Robot Control w/ XInput
-  - BOARD=xinput:avr:robotControl
-  - buildSketch
+  - BOARD=xinput:avr:robotControl; buildSketch;
 
   # Arduino Arduino Robot Motor w/ XInput
-  - BOARD=xinput:avr:robotMotor
-  - buildSketch
+  - BOARD=xinput:avr:robotMotor; buildSketch;
 
   # Adafruit Circuit Playground 32u4 w/Caterina Configuration w/ XInput
-  - BOARD=xinput:avr:circuitplay32u4cat
-  - buildSketch
+  - BOARD=xinput:avr:circuitplay32u4cat; buildSketch;
 
   # Arduino Yún Mini w/ XInput
-  - BOARD=xinput:avr:yunmini
-  - buildSketch
+  - BOARD=xinput:avr:yunmini; buildSketch;
 
   # Arduino Industrial 101 w/ XInput
-  - BOARD=xinput:avr:chiwawa
-  - buildSketch
+  - BOARD=xinput:avr:chiwawa; buildSketch;
 
   # Linino One w/ XInput
-  - BOARD=xinput:avr:one
-  - buildSketch
+  - BOARD=xinput:avr:one; buildSketch;
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ before_install:
     }
 
 install:
-  - mkdir -p $BOARDS_DESTINATION/xinput/avr
   - ln -s $PWD $BOARDS_DESTINATION/xinput/avr
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_install:
     }
 
 install:
+  - mkdir $BOARDS_DESTINATION/xinput
   - ln -s $PWD $BOARDS_DESTINATION/xinput/avr
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,98 @@
+language: C
+env:
+  global:
+    - IDE_VERSION=1.8.1
+    - IDE_LOCATION=/usr/local/share/arduino
+    - BOARDS_DESTINATION=$IDE_LOCATION/hardware
+
+matrix:
+  include:
+    - name: "Blank Sketch"
+      env: SKETCH="$IDE_LOCATION/examples/01.Basics/BareMinimum/BareMinimum.ino"
+    - name: "USB API Demo"
+      env: SKETCH="$IDE_LOCATION/libraries/ArduinoXInput/extras/API-Demo/API-Demo.ino"
+    - name: "XInput Library"
+      env: SKETCH="$IDE_LOCATION/libraries/ArduinoXInput/examples/GamepadPins/GamepadPins.ino"
+
+before_install:
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
+  - sleep 3
+  - export DISPLAY=:1.0
+
+  # Install Arduino IDE
+  - wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz
+  - tar xf arduino-$IDE_VERSION-linux64.tar.xz
+  - sudo mv arduino-$IDE_VERSION $IDE_LOCATION
+  - sudo ln -s $IDE_LOCATION/arduino /usr/local/bin/arduino
+  - rm arduino-$IDE_VERSION-linux64.tar.xz
+
+  # Install XInput Library
+  - if [[ $SKETCH == *"ArduinoXInput"* ]]; then
+      git clone https://github.com/dmadison/ArduinoXInput.git;
+      mv ArduinoXInput $IDE_LOCATION/libraries;
+    fi
+
+  # Sketch Compiling Functions
+  - CYAN="\033[36m"; NOC="\033[0m";
+  - buildSketch() {
+      echo -e "\n${CYAN}Building sketch ${SKETCH##*/} for $BOARD${NOC}";
+      arduino --verify --board $BOARD "$SKETCH";
+    }
+
+install:
+  - mkdir -p $BOARDS_DESTINATION/xinput/avr
+  - ln -s $PWD $BOARDS_DESTINATION/xinput/avr
+
+script:
+  # Arduino Yún w/ XInput
+  - BOARD=xinput:avr:yun
+  - buildSketch
+
+  # Arduino Leonardo w/ XInput
+  - BOARD=xinput:avr:leonardo
+  - buildSketch
+
+  # Arduino Arduino Leonardo ETH w/ XInput
+  - BOARD=xinput:avr:leonardoeth
+  - buildSketch
+
+  # Arduino/Genuino Micro w/ XInput
+  - BOARD=xinput:avr:micro
+  - buildSketch
+
+  # Arduino Esplora w/ XInput
+  - BOARD=xinput:avr:esplora
+  - buildSketch
+
+  # LilyPad Arduino USB w/ XInput
+  - BOARD=xinput:avr:LilyPadUSB
+  - buildSketch
+
+  # Arduino Robot Control w/ XInput
+  - BOARD=xinput:avr:robotControl
+  - buildSketch
+
+  # Arduino Arduino Robot Motor w/ XInput
+  - BOARD=xinput:avr:robotMotor
+  - buildSketch
+
+  # Adafruit Circuit Playground 32u4 w/Caterina Configuration w/ XInput
+  - BOARD=xinput:avr:circuitplay32u4cat
+  - buildSketch
+
+  # Arduino Yún Mini w/ XInput
+  - BOARD=xinput:avr:yunmini
+  - buildSketch
+
+  # Arduino Industrial 101 w/ XInput
+  - BOARD=xinput:avr:chiwawa
+  - buildSketch
+
+  # Linino One w/ XInput
+  - BOARD=xinput:avr:one
+  - buildSketch
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # XInput USB Core for Arduino AVR
+[![Build Status](https://travis-ci.org/dmadison/ArduinoXInput_AVR.svg?branch=master)](https://travis-ci.org/dmadison/ArduinoXInput_AVR)
 
 The files in this repository allow you to emulate an Xbox gamepad (XInput) using a USB-capable Arduino microcontroller. Originally forked from [the official Arduino AVR core](https://github.com/arduino/ArduinoCore-avr).
 


### PR DESCRIPTION
Adds Travis CI support, checking all supported boards with three sketches: 

* Blank Sketch (does anything compile?)
* USB API Demo (are the API functions present and compiling?)
* XInput Library "GamepadPins" example (does the library work?)

Should provide reasonable coverage that all boards are compiling correctly. Although it doesn't tell me anything about the resultant USB functionality.