### PR TITLE
Merge upstream tag '1.8.8'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install Arduino IDE
         run: |

--- a/.github/workflows/compile-platform-examples.yml
+++ b/.github/workflows/compile-platform-examples.yml
@@ -240,7 +240,7 @@ jobs:
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save sketches report as workflow artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -334,14 +334,16 @@ unsigned char String::concat(unsigned long num)
 
 unsigned char String::concat(float num)
 {
-	char buf[20];
+	static size_t const FLOAT_BUF_SIZE = (FLT_MAX_10_EXP + 1) + 2 /* FIXED DECIMAL PLACES */ + 1 /* '-' */ + 1 /* '.' */ + 1 /* '\0' */;
+	char buf[FLOAT_BUF_SIZE];
 	char* string = dtostrf(num, 4, 2, buf);
 	return concat(string, strlen(string));
 }
 
 unsigned char String::concat(double num)
 {
-	char buf[20];
+	static size_t const DOUBLE_BUF_SIZE = (DBL_MAX_10_EXP + 1) + 2 /* FIXED DECIMAL PLACES */ + 1 /* '-' */ + 1 /* '.' */ + 1 /* '\0' */;
+	char buf[DOUBLE_BUF_SIZE];
 	char* string = dtostrf(num, 4, 2, buf);
 	return concat(string, strlen(string));
 }

--- a/platform.txt
+++ b/platform.txt
@@ -6,7 +6,7 @@
 # https://arduino.github.io/arduino-cli/latest/platform-specification/
 
 name=Arduino AVR Boards
-version=1.8.7
+version=1.8.8
 
 # AVR compile variables
 # ---------------------

--- a/platform.txt
+++ b/platform.txt
@@ -6,7 +6,7 @@
 # https://arduino.github.io/arduino-cli/latest/platform-specification/
 
 name=XInput AVR Boards
-version=1.0.6
+version=1.0.7
 
 # AVR compile variables
 # ---------------------


### PR DESCRIPTION
Updates this repo to [Arduino AVR core 1.8.8](https://github.com/arduino/ArduinoCore-avr/releases/tag/1.8.8).

This update contains no functional changes to the XInput code.